### PR TITLE
Manually cast timer interval to int.

### DIFF
--- a/qreactor.py
+++ b/qreactor.py
@@ -288,7 +288,7 @@ class QtReactor(posixbase.PosixReactorBase):
             self.qApp.processEvents(QEventLoop.AllEvents, delay * 1000)
         timeout = self.timeout()
         if timeout is not None:
-            self._timer.setInterval(timeout * 1000)
+            self._timer.setInterval(int(timeout * 1000))
             self._timer.start()
 
     def runReturn(self, installSignalHandlers=True):


### PR DESCRIPTION
Otherwise causes an exception when calling calling twisted.internet.task.deferLater with qt5 or qt6 . 

